### PR TITLE
fix: include the missing data required for detail preview

### DIFF
--- a/src/EnhancedMarkdown.php
+++ b/src/EnhancedMarkdown.php
@@ -117,7 +117,7 @@ class EnhancedMarkdown extends Trix implements Previewable
     {
         return array_merge(parent::jsonSerialize(), [
             'shouldShow' => $this->shouldBeExpanded(),
-            'preset' => $this->preset,
+            'preset'     => $this->preset,
             'previewFor' => $this->previewFor($this->value ?? ''),
         ]);
     }

--- a/src/EnhancedMarkdown.php
+++ b/src/EnhancedMarkdown.php
@@ -115,10 +115,10 @@ class EnhancedMarkdown extends Trix implements Previewable
      */
     public function jsonSerialize(): array
     {
-        $serialized = parent::jsonSerialize();
-
-        $serialized['preset'] = $this->preset;
-
-        return $serialized;
+        return array_merge(parent::jsonSerialize(), [
+            'shouldShow' => $this->shouldBeExpanded(),
+            'preset' => $this->preset,
+            'previewFor' => $this->previewFor($this->value ?? ''),
+        ]);
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Currently the preview on the Nova details screen is not working, this PR should solve the problem. At the moment "show content" results in an empty field: 
<img width="604" alt="image" src="https://user-images.githubusercontent.com/35610748/195335083-b3ac901a-f530-4a81-9962-17c40ba07362.png">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
