### PR TITLE
chore: remove dependency pinning to latest version

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -3,6 +3,7 @@ name: Dependencies
 on:
     schedule:
         - cron: "0 0 * * 0"
+    workflow_dispatch:
 
 jobs:
     update:
@@ -15,7 +16,7 @@ jobs:
                   token: ${{ secrets.GH_TOKEN }}
 
             - name: Update dependencies
-              run: npx @faustbrian/node-composer-check-updates --caret-minor
+              run: npx @faustbrian/node-composer-check-updates
 
             - name: Authenticate Nova
               run: composer config http-basic.nova.laravel.com ${{ secrets.NOVA_USERNAME }} ${{ secrets.NOVA_LICENSE_KEY }}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^9.34",
+        "laravel/framework": "^9.0",
         "laravel/nova": "^4.0",
         "spatie/image": "^2.2",
         "spatie/image-optimizer": "^1.6"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Removes `--caret-minor` from the dep update workflow to not force users to the latest versions of packages by default

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
